### PR TITLE
Add Docs CG charter

### DIFF
--- a/docs-cg.md
+++ b/docs-cg.md
@@ -13,7 +13,7 @@ This Community will:
   - Identify needs for Guides, How-Tos, and Tutorials and create them.
 - Work with specification authors to define best practices for web developer docs, code examples, and information architecture.
 - Maintain and keep documentation up-to-date using modern approaches like docs-as-code and develop tools to create feedback loops between standards and web developer documentation.
-- Collaborate with other horizontal groups such as WebDX, Security, Privacy, Accessibility, Internationalization, Sustainability and integrate their findings and best practices into docs.
+- Collaborate with other horizontal groups such as [WebDX](https://www.w3.org/community/webdx/), [Security](https://www.w3.org/mission/security/), [Privacy](https://www.w3.org/mission/privacy/), [Accessibility](https://www.w3.org/mission/accessibility/), [Internationalization](https://www.w3.org/mission/internationalization/), [Sustainability](https://www.w3.org/community/sustyweb/) and integrate their findings and best practices into docs.
 - Create a map of documentation sources for web developers.
   - Identify reliable sources of information.
   - Invite them to be part of the conversations in the CG.
@@ -28,7 +28,6 @@ This Community will:
 - Write and maintain docs in [mdn/content](https://github.com/mdn/content). See the [backlog](https://openwebdocs.github.io/web-docs-backlog/) for missing reference pages.
 - Identify best practices for web developer documentation.
 - Drive adoption and understanding of web technologies.
-- Act as a hub to coordinate documentation projects.
 
 ## Out of scope
 
@@ -37,24 +36,23 @@ The group may produce Community Group Reports within the scope of this charter b
 ## Dependencies or liaisons
 
 - Groups
-  - Open Web Docs
-  - Web Developer Experience (WebDX) Community Group
-  - Webref & spec tooling maintainers
-  - SWAG Community Group
-  - TAG (especially related to “explainers”)
-  - OWASP docs
+  - [Open Web Docs](https://openwebdocs.org)
+  - [Web Developer Experience (WebDX) Community Group](https://www.w3.org/community/webdx/)
+  - [Webref & spec tooling maintainers](https://www.w3.org/community/speced-cg/)
+  - [SWAG Community Group](https://www.w3.org/community/swag/)
+  - [TAG](https://www.w3.org/2001/tag/) (especially related to “explainers”)
+  - [OWASP](https://owasp.org) docs
   - [OSTIF](https://ostif.org/)
-  - Write The Docs community
-  - ARIA Practices Guide Taskforce (a subgroup of ARIA WG) who owns/maintains [APG](https://www.w3.org/WAI/ARIA/apg/).
+  - [Write The Docs](https://www.writethedocs.org) community
+  - [ARIA Practices Guide Taskforce](https://www.w3.org/WAI/about/groups/task-forces/practices/) (a subgroup of ARIA WG) who owns/maintains [APG](https://www.w3.org/WAI/ARIA/apg/).
 - Docs sites
-  - MDN Web Docs
-  - CanIUse
-  - web.dev
-  - learn.microsoft.com
-  - devdocs.io
-  - Freecodecamp
-  - w3schools
-  - Popular front-end sites/blogs which also document the web, for example: [css-tricks.com](https://css-tricks.com/almanac/pseudo-selectors/)
+  - [MDN Web Docs](https://developer.mozilla.org)
+  - [CanIUse](https://caniuse.com)
+  - [web.dev](https://web.dev)
+  - [learn.microsoft.com](https://learn.microsoft.com)
+  - [devdocs.io](https://devdocs.io)
+  - [Freecodecamp](https://www.freecodecamp.org)
+  - Popular front-end sites/blogs which also document the web, for example: [css-tricks.com](https://css-tricks.com/almanac/pseudo-selectors/), [w3schools](https://www.w3schools.com), ...
   - Translated docs, for example: [Doka: web docs for Russian speaking developers](https://doka.guide/)
 
 ## Audience

--- a/docs-cg.md
+++ b/docs-cg.md
@@ -2,7 +2,7 @@
 
 ## Mission
 
-The mission of the W3C Documentation Community Group (W3C Docs CG) is to ensure web developers and designers worldwide have the best information available so they can build things on the web platform. The Docs CG focuses on the art of technical writing and information architecture across the Web ecosystem (W3C, WHATWG, ECMA, IETF, etc.).
+The mission of the W3C Documentation Community Group (W3C Docs CG) is to ensure web developers and designers worldwide have the best information available so they can build things on the web platform.
 
 ## Scope of work
 
@@ -61,7 +61,7 @@ The group may produce Community Group Reports within the scope of this charter b
 
 Who is this CG for?
 
-- Technical Writers to talk amongst themselves.
+- Technical writers and other documentation practitioners to collaborate.
 - Web platform docs sites to share best practices.
-- Specification authors and implementers to give and to get feedback on docs and specs.
-- Web developers to help identify needs in understanding web platform technologies.
+- Specification authors and implementers to give and receive feedback on documentation and specs.
+- Web developers to identify and request support to better the understanding of web platform technologies.

--- a/docs-cg.md
+++ b/docs-cg.md
@@ -1,0 +1,67 @@
+# W3C Documentation CG Charter
+
+## Mission
+
+The mission of the W3C Documentation Community Group (W3C Docs CG) is to ensure web developers and designers worldwide have the best information available so they can build things on the web platform. The Docs CG focuses on the art of technical writing and information architecture across the Web ecosystem (W3C, WHATWG, ECMA, IETF, etc.).
+
+## Scope of work
+
+This Community will:
+
+- Plan and write new documentation for web platform technologies.
+  - Make sure reference docs (“the book of web platform features”) are complete.
+  - Identify needs for Guides, How-Tos, and Tutorials and create them.
+- Work with specification authors to define best practices for web developer docs, code examples, and information architecture.
+- Maintain and keep documentation up-to-date using modern approaches like docs-as-code and develop tools to create feedback loops between standards and web developer documentation.
+- Collaborate with other horizontal groups such as WebDX, Security, Privacy, Accessibility, Internationalization, Sustainability and integrate their findings and best practices into docs.
+- Create a map of documentation sources for web developers.
+  - Identify reliable sources of information.
+  - Invite them to be part of the conversations in the CG.
+- Drive adoption (or deprecation!) of web platform technologies.
+  - Identify web platform features where sparse docs prevent adoption and understanding.
+  - Interpret developer surveys (such as the [MDN short survey on web Developer’s experience with Web Security](https://github.com/web-platform-dx/developer-research/blob/main/mdn-short-surveys/2023-05-15-security-dx/interpretation.md) and understand the role of documentation in identified shortcomings.
+- Coordinate horizontal efforts to get outdated docs updated by, e.g. helping reach out to the right docs owners.
+- Act as a hub for when docs-related efforts/changes/projects appear, so people can get these amplified/coordinated with the relevant stakeholders.
+
+## Key deliverables
+
+- Write and maintain docs in [mdn/content](https://github.com/mdn/content). See the [backlog](https://openwebdocs.github.io/web-docs-backlog/) for missing reference pages.
+- Identify best practices for web developer documentation.
+- Drive adoption and understanding of web technologies.
+- Act as a hub to coordinate documentation projects.
+
+## Out of scope
+
+The group may produce Community Group Reports within the scope of this charter but not Specifications.
+
+## Dependencies or liaisons
+
+- Groups
+  - Open Web Docs
+  - Web Developer Experience (WebDX) Community Group
+  - Webref & spec tooling maintainers
+  - SWAG Community Group
+  - TAG (especially related to “explainers”)
+  - OWASP docs
+  - [OSTIF](https://ostif.org/)
+  - Write The Docs community
+  - ARIA Practices Guide Taskforce (a subgroup of ARIA WG) who owns/maintains [APG](https://www.w3.org/WAI/ARIA/apg/).
+- Docs sites
+  - MDN Web Docs
+  - CanIUse
+  - web.dev
+  - learn.microsoft.com
+  - devdocs.io
+  - Freecodecamp
+  - w3schools
+  - Popular front-end sites/blogs which also document the web, for example: [css-tricks.com](https://css-tricks.com/almanac/pseudo-selectors/)
+  - Translated docs, for example: [Doka: web docs for Russian speaking developers](https://doka.guide/)
+
+## Audience
+
+Who is this CG for?
+
+- Technical Writers to talk amongst themselves.
+- Web platform docs sites to share best practices.
+- Specification authors and implementers to give and to get feedback on docs and specs.
+- Web developers to help identify needs in understanding web platform technologies.

--- a/docs-cg.md
+++ b/docs-cg.md
@@ -6,22 +6,23 @@ The mission of the W3C Documentation Community Group (W3C Docs CG) is to ensure 
 
 ## Scope of work
 
-This Community will:
+This community group will:
 
 - Plan and write new documentation for web platform technologies.
-  - Make sure reference docs (“the book of web platform features”) are complete.
-  - Identify needs for Guides, How-Tos, and Tutorials and create them.
-- Work with specification authors to define best practices for web developer docs, code examples, and information architecture.
-- Maintain and keep documentation up-to-date using modern approaches like docs-as-code and develop tools to create feedback loops between standards and web developer documentation.
-- Collaborate with other horizontal groups such as [WebDX](https://www.w3.org/community/webdx/), [Security](https://www.w3.org/mission/security/), [Privacy](https://www.w3.org/mission/privacy/), [Accessibility](https://www.w3.org/mission/accessibility/), [Internationalization](https://www.w3.org/mission/internationalization/), [Sustainability](https://www.w3.org/community/sustyweb/) and integrate their findings and best practices into docs.
-- Create a map of documentation sources for web developers.
+  - Make sure reference documentation (“the book of web platform features”) is complete.
+  - Identify needs for guides, how-tos, and tutorials, and create them.
+- Work with specification authors to define best practices for web developer documentation, code examples, and information architecture.
+- Maintain and keep documentation up-to-date using modern approaches like docs-as-code
+- Develop tools to create feedback loops between standards and web developer documentation.
+- Coordinate documentation efforts: Collaborate with other W3C community groups, such as [WebDX](https://www.w3.org/community/webdx/), [Security](https://www.w3.org/mission/security/), [Privacy](https://www.w3.org/mission/privacy/), [Accessibility](https://www.w3.org/mission/accessibility/), [Internationalization](https://www.w3.org/mission/internationalization/), [Sustainability](https://www.w3.org/community/sustyweb/) and integrate their findings and best practices into documentation.
+- Be a resource for resources: map documentation sources for web developers.
   - Identify reliable sources of information.
-  - Invite them to be part of the conversations in the CG.
-- Drive adoption (or deprecation!) of web platform technologies.
+  - Invite them to be part of the conversations in this community group.
+- Drive adoption (or deprecation) of web platform technologies:
   - Identify web platform features where sparse docs prevent adoption and understanding.
-  - Interpret developer surveys (such as the [MDN short survey on web Developer’s experience with Web Security](https://github.com/web-platform-dx/developer-research/blob/main/mdn-short-surveys/2023-05-15-security-dx/interpretation.md) and understand the role of documentation in identified shortcomings.
-- Coordinate horizontal efforts to get outdated docs updated by, e.g. helping reach out to the right docs owners.
-- Act as a hub for when docs-related efforts/changes/projects appear, so people can get these amplified/coordinated with the relevant stakeholders.
+  - Interpret developer surveys (such as the [MDN short survey on web developer’s experience with Web Security](https://github.com/web-platform-dx/developer-research/blob/main/mdn-short-surveys/2023-05-15-security-dx/interpretation.md) and understand the role of documentation in identified shortcomings.
+- Ensure documentation relevance: coordinate horizontal efforts to get outdated docs updated such as by helping reach out to the right docs owners.
+- Be a hub for web documentation: when docs-related efforts, changes, and/or projects appear, coordinate with the relevant stakeholders to get these amplified.
 
 ## Key deliverables
 


### PR DESCRIPTION
As presented at the W3C Breakouts Day 2025 (https://github.com/w3c/breakouts-day-2025/issues/10), here's the proposed charter for the W3C Docs CG.

Minutes: https://www.w3.org/2025/03/26-web-platform-doc-minutes.html
Slides: https://docs.google.com/presentation/d/1Ju2Pj52HI5z63KIUKvWfbFEOWBDzjhFEDjI9Vb_ochA/edit

I'd like to get feedback on this charter until April 9, 2025.